### PR TITLE
update obsolete createJavaScriptNode with createScriptProcessor

### DIFF
--- a/public/RecordRTC.js
+++ b/public/RecordRTC.js
@@ -337,7 +337,7 @@ function StereoAudioRecorder(mediaStream, root) {
     console.log('sample-rate', sampleRate);
     console.log('buffer-size', bufferSize);
 
-    recorder = context.createJavaScriptNode(bufferSize, 2, 2);
+    recorder = context.createScriptProcessor(bufferSize, 2, 2);
 
     recorder.onaudioprocess = function(e) {
         if (!recording) return;


### PR DESCRIPTION
I found this very useful, I just ran into an error when trying to run it. It turns out that one of the api methods was obsolete, this updates the method to use the new createScriptProcessor.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/AudioContext.createJavaScriptNode
